### PR TITLE
Update w2form.js

### DIFF
--- a/src/w2form.js
+++ b/src/w2form.js
@@ -1045,7 +1045,7 @@
                     case 'list':
                     case 'combo':
                         if (field.type == 'list') {
-                            var tmp_value = ($.isPlainObject(value) ? value.id : value);
+                            var tmp_value = ($.isPlainObject(value) ? value.id : ($.isPlainObject(field.options.selected) ? field.options.selected.id : value));
                             // normalized options
                             if (!field.options.items) field.options.items = [];
                             var items = field.options.items;


### PR DESCRIPTION
# issue 1031 If 'value' is empty from record, then get selected item from 'field.options.selected'.
